### PR TITLE
Update acrylic_glass.gd

### DIFF
--- a/addons/acrylic_glass/acrylic_glass.gd
+++ b/addons/acrylic_glass/acrylic_glass.gd
@@ -86,9 +86,10 @@ func get_wallpaper() -> Dictionary:
 		"Linux":
 			var output := []
 			OS.execute("gsettings", ["get", "org.gnome.desktop.background", "picture-uri"], output)
-			output[0].replace("file://", "")
-			err = image.load(output[0])
-			wallpaper_info.checksum = FileAccess.get_md5(output[0])
+			var filepath: String = output[0]
+			filepath = filepath.replace("file://", "").replace("'", "").strip_edges()
+			err = image.load(filepath)
+			wallpaper_info.checksum = FileAccess.get_md5(filepath)
 	
 	if err == OK:
 		wallpaper_info.texture = ImageTexture.create_from_image(image)


### PR DESCRIPTION
Fixed Linux support:
On some Linux distros this error would popup "cannot call method 'get_width' on a null value.". The lines of code proposed fix this issue.